### PR TITLE
ci: add release-please-guard caller workflow

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,0 +1,11 @@
+---
+name: release-please-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please-guard.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

- Add `release-please-guard` caller workflow using the reusable workflow from `github-workflows-polarion`
- Tests SchweizerischeBundesbahnen/github-workflows-polarion#73 before rolling out to the template repo (SchweizerischeBundesbahnen/open-source-polarion-java-repo-template#132)

## Test plan

- [ ] Verify `release-please-guard` check passes on this PR (base branch has SNAPSHOT version)