### PR TITLE
test: verify release-please-guard reusable workflow

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,0 +1,11 @@
+---
+name: release-please-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please-guard.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Test PR to verify the reusable `release-please-guard` workflow works correctly.

Base branch version is `1.3.22-SNAPSHOT` — the guard should **pass**.

**Close without merging after verification.**

## Related

- SchweizerischeBundesbahnen/github-workflows-polarion#73
- SchweizerischeBundesbahnen/open-source-polarion-java-repo-template#132